### PR TITLE
Tweak build push workflow

### DIFF
--- a/.github/workflows/build-and-push-images.yaml
+++ b/.github/workflows/build-and-push-images.yaml
@@ -28,7 +28,7 @@ jobs:
       - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
       - id: gcp-auth
         name: Google authentication
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193
         with:
           token_format: "access_token"
           service_account: artifact-writer@${{ env.GCP_PROJECT_ID }}.iam.gserviceaccount.com

--- a/.github/workflows/build-and-push-images.yaml
+++ b/.github/workflows/build-and-push-images.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
   workflow_dispatch: {}
 
 env:

--- a/.github/workflows/build-and-push-images.yaml
+++ b/.github/workflows/build-and-push-images.yaml
@@ -23,6 +23,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-tags: true
       - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
       - id: gcp-auth
         name: Google authentication

--- a/.github/workflows/build-and-push-images.yaml
+++ b/.github/workflows/build-and-push-images.yaml
@@ -22,8 +22,8 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
       - id: gcp-auth
         name: Google authentication
         uses: google-github-actions/auth@v2
@@ -32,7 +32,7 @@ jobs:
           service_account: artifact-writer@${{ env.GCP_PROJECT_ID }}.iam.gserviceaccount.com
           workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Log in to the GAR container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
         with:
           registry: ${{ env.GAR_LOCATION }}-docker.pkg.dev
           username: oauth2accesstoken

--- a/.github/workflows/build-and-push-images.yaml
+++ b/.github/workflows/build-and-push-images.yaml
@@ -12,7 +12,7 @@ env:
   IMAGE_NAME: go-demo
   GAR_LOCATION: us
   GCP_PROJECT_ID: moz-fx-cicd-demos-nonprod
-  IMAGE_NAMESPACE: us-docker.pkg.dev/moz-fx-cicd-demos-nonprod/cicd-demos-nonprod
+  GAR_IMAGE_NAMESPACE: us-docker.pkg.dev/moz-fx-cicd-demos-nonprod/cicd-demos-nonprod
 
 jobs:
   build-and-push:
@@ -48,15 +48,37 @@ jobs:
       - name: Run the release script to build version.json file
         working-directory: ./go-demo
         run: ./release.sh
+      - name: Generate MozCloud Tag
+        id: mozcloud-tag
+        shell: bash
+        run: |
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            tag=${{ github.ref_name }}"
+          else
+            tag=$(git rev-parse --short=10 HEAD)"
+          fi
+          # append metadata if present
+          if [[ -n "${{ env.METADATA }}" ]]; then
+            tag="${tag}--${{ env.METADATA }}"
+          fi
+          echo "IMAGE_TAG=${tag}" >> "$GITHUB_OUTPUT"        
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804
+        with:
+          images: |
+            ${{ env.GAR_IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+            ghcr.io/${{ github.repository }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.mozcloud-tag.outputs.IMAGE_TAG }}
+            type=raw,value=latest
       - name: Build and push image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           context: ./go-demo/
-          tags: |
-            ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
-            ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}:latest
-            ghcr.io/${{ github.repository }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
-            ghcr.io/${{ github.repository }}/${{ env.IMAGE_NAME }}:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
This PR:
- pins all actions to a SHA (a security best practice)
- Adds steps to:
  - generate a Mozcloud-compliant tag
  - apply that tag (along with labels and annotations) to the built image with `docker/metadata-action`

After we merge this PR, the next step will be to "extract" the core logic into a reusable workflow, then test that workflow by "foxfooding" it in this repo.